### PR TITLE
13 - a typo for the css filename was causing the extension to fail wh…

### DIFF
--- a/chrome/manifest.prod.json
+++ b/chrome/manifest.prod.json
@@ -26,7 +26,7 @@
       "matches": [
         "<all_urls>"
       ],
-      "css": ["better_comment.css", "ccbModal.css"]
+      "css": ["better_comment.css", "cbbModal.css"]
     }
   ]
 }


### PR DESCRIPTION
…en loaded by chrome.