### PR TITLE
Limit modal stylesheet to fb

### DIFF
--- a/chrome/manifest.dev.json
+++ b/chrome/manifest.dev.json
@@ -25,7 +25,13 @@
     "matches": [
       "<all_urls>"
     ],
-    "css": ["better_comment.css", "cbbModal.css"]
+    "css": ["better_comment.css"]
+  },
+  {
+    "matches": [
+      "https://www.facebook.com/*"
+    ],
+    "css": ["cbbModal.css"]
   }
   ]
 }


### PR DESCRIPTION
Modal css previously applied to all urls caused issues with websites currently unrelated to comment-better button (e.g. Stack Overflow background changed to orange, song elements disappeared from YouTube playlist menu, etc.). Modal css is now limited to Facebook to avoid unintended styling issues.